### PR TITLE
Fixes "permission denied" errors 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Bank and similar (SafetyNet) apps should still work but might require you to re-
 5. Open a terminal with adb and run the following
    1. `adb shell`
    2. `su`
-   3. `cd /sdcard/ && chmod +x globalify.sh && ./globalify.sh`
+   3. `cd /data/local/tmp`
+   4. `mv /sdcard/globalify.sh ./`
+   5. `chmod +x globalify.sh && ./globalify.sh`
 6. Exit adb shell and run `adb reboot recovery`. You might have to press Volume Up + Power to get past the "No Command" screen.
 7. Pick the sideload through adb option.
 8. `adb sideload name_of_duo_global_ota.zip`, This might fail at 94-98%; but should still work. If not just boot into recovery and retry from step 6.

--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ Bank and similar (SafetyNet) apps should still work but might require you to re-
 7. Pick the sideload through adb option.
 8. `adb sideload name_of_duo_global_ota.zip`, This might fail at 94-98%; but should still work. If not just boot into recovery and retry from step 6.
 9. Reboot.
-10. Profit!!!
+10. Profit!!!!
 11. Support me on [GitHub Sponsors](https://github.com/sponsors/filiphsandstrom) if you'd like to say thanks :D


### PR DESCRIPTION
Fixes "permission denied" errors that occurs when trying to chmod a file in /sdcard by moving the file. Since your .sh script contains absolute paths for the dd commands, it does not matter where the globalify.sh script is run